### PR TITLE
Update SSM Wrapper to use origin-format json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ Once this repository is cloned down, be sure to run the following commands from 
 | --key | -k | The KMS key to encrypt the param(s) with. | yes |
 | --path | -p | The path to add or update parameters at. | yes |
 | --overwrite | -o | Whether to overwrite or not. Defaults to false. | no |
+| --format | --fmt | JSON file format. Accepts `simple, default`. | no |
 
 #### List
 | Flag | Alias | Description | Required |
 | ----- | ----- | ----------- | -------- |
 | --path | -p | The path to add or update parameters at. | yes |
 | --result | -r | Output result format. Defaults to formatted table. Accepts `json, table`. | no |
+| --format | -f | The Output Json format. Accepts `simple, default`. | no |
 
 #### Delete
 | Flag | Alias | Description | Required |
@@ -116,6 +118,14 @@ Can contain one or more parameters.
 ]
 ```
 
+`simple` format:
+```json
+{
+    "k1": "10101010",
+    "k2": "20202020",
+    "k3": "30303030"
+}
+```
 ---
 
 ### AWS API Errors

--- a/commands/addUpdate.js
+++ b/commands/addUpdate.js
@@ -37,23 +37,19 @@ exports.handler = async (argv) => {
 };
 
 const addUpdateParams = async (yargs) => {
-  const params = JSON.parse(fs.readFileSync(yargs.file));
-  let awsParams = {};
-  for (let i = 0; i < params.length; i++) {
-    awsParams['Name'] = `/${yargs.path}/${params[i].key}`;
-    awsParams['Value'] = params[i].value;
-    awsParams['Type'] = params[i].type;
+  const params = JSON.parse(fs.readFileSync(yargs.file, 'utf8'));
+  for(var key in params){
+    let awsParams = {};
+    awsParams['Name'] = `/${yargs.path}/${key}`;
+    awsParams['Value'] = params[key];
+    awsParams['Type'] = 'SecureString';
     awsParams['Overwrite'] = yargs.o;
-    if (params[i].type === 'SecureString') {
-      awsParams['KeyId'] = yargs.k;
-    } else {
-      delete awsParams['KeyId'];
-    }
+    awsParams['KeyId'] = yargs.k
     ssm.putParameter(awsParams, (err, data) => {
       if (err) {
         errResp(err.code, err.stack, awsParams)
       } else {
-        console.info(`Added: ${awsParams.Name}`)
+        console.log(`Added (Updated): /${yargs.path}/${key}`)
       }
     })
     await sleep(1000)

--- a/commands/list.js
+++ b/commands/list.js
@@ -2,7 +2,7 @@ const aws = require('aws-sdk');
 const ssm = new aws.SSM({ apiVersion: '2014-11-06' });
 const errResp = require('../utils/errors').errorResp;
 
-let getParamList = [];
+let getParamList = {};
 
 exports.command = 'list';
 exports.aliases = ['ls', 'get'];
@@ -44,11 +44,16 @@ const getParams = async (yargs) => {
             // redact certificate values for consistent formatting when listing to table
             data.Parameters[i].Value = 'CERT REDACTED';
           }
+          /* 
           getParamList.push({
             key: data.Parameters[i].Name.replace(`/${yargs.p}/`, ''),
             value: data.Parameters[i].Value,
             type: data.Parameters[i].Type,
           });
+          */
+
+         // Generating key:value array for saving as single JSON object in a file
+          getParamList[data.Parameters[i].Name.replace(`/${yargs.p}/`, '')] = data.Parameters[i].Value;
         }
         if (data.NextToken) {
           getAWSParams(data.NextToken);

--- a/commands/list.js
+++ b/commands/list.js
@@ -2,7 +2,7 @@ const aws = require('aws-sdk');
 const ssm = new aws.SSM({ apiVersion: '2014-11-06' });
 const errResp = require('../utils/errors').errorResp;
 
-let getParamList = {};
+let getParamList;
 
 exports.command = 'list';
 exports.aliases = ['ls', 'get'];
@@ -15,6 +15,11 @@ exports.builder = (yargs) => {
       path: {
         alias: 'p',
         describe: 'The SSM path to list from.'
+      },
+      format: {
+        alias: 'f',
+        default: 'default',
+        describe: 'The Output Json format. Accepts `simple, default`. '
       },
       result: {
         alias: 'r',
@@ -33,6 +38,12 @@ const getParams = async (yargs) => {
   awsParams['Path'] = `/${yargs.p}`;
   awsParams['Recursive'] = true;
   awsParams['WithDecryption'] = true;
+  if (yargs.f === 'default') {
+    getParamList = [];
+  }
+  if (yargs.f === 'simple') {
+    getParamList = {};
+  }
   const getAWSParams = (token) => {
     if (token) awsParams['NextToken'] = token;
     ssm.getParametersByPath(awsParams, (err, data) => {
@@ -44,16 +55,18 @@ const getParams = async (yargs) => {
             // redact certificate values for consistent formatting when listing to table
             data.Parameters[i].Value = 'CERT REDACTED';
           }
-          /* 
-          getParamList.push({
-            key: data.Parameters[i].Name.replace(`/${yargs.p}/`, ''),
-            value: data.Parameters[i].Value,
-            type: data.Parameters[i].Type,
-          });
-          */
+          if (yargs.f === 'default') {
+            getParamList.push({
+              key: data.Parameters[i].Name.replace(`/${yargs.p}/`, ''),
+              value: data.Parameters[i].Value,
+              type: data.Parameters[i].Type,
+            });
+          }
+          if (yargs.f === 'simple') {
+            // Generating key:value array for saving as single JSON object in a file
+            getParamList[data.Parameters[i].Name.replace(`/${yargs.p}/`, '')] = data.Parameters[i].Value;
+          }
 
-         // Generating key:value array for saving as single JSON object in a file
-          getParamList[data.Parameters[i].Name.replace(`/${yargs.p}/`, '')] = data.Parameters[i].Value;
         }
         if (data.NextToken) {
           getAWSParams(data.NextToken);


### PR DESCRIPTION
- Updated List and Add features for using origin-format json files
- Added **--format** flag for a simple json

Example of commands:
- ssm add -f /home/igor/github/hazelops/ssm-wrapper/test.json -p ihar -k alias/aws/ssm **--format simple**
- ssm list -p ihar -r json **-f simple**